### PR TITLE
Prevent key generation for the same e-mail again

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -64,6 +64,8 @@ router.route('/generate')
           };
           if(!jsonData || jsonData.length<1)
             jsonData=[];
+          if (jsonData.filter(x => x.email === req.props.email).length > 0)
+            return res.json({ status: 'Failure', data: 'E-mail already exists.' });
           jsonData.push(data);
           fs.writeFileSync('api_data.json', JSON.stringify(jsonData));
           result=key;


### PR DESCRIPTION
# Prevent key generation for the same e-mail again
Resolves #2: **Prevent new key generation for already present emails**

The only modification is in the `routes/index.js` file.
``` js
...
if(!jsonData || jsonData.length<1)
  jsonData=[];
if (jsonData.filter(x => x.email === req.props.email).length > 0)
  return res.json({ status: 'Failure', data: 'E-mail already exists.' });
...
```

This discontinues the key-generation if the e-mail address already exists.